### PR TITLE
Fix Revit 2025/2026 build: convert to SDK-style csproj with .NET 8 su…

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: windows-latest
 
     strategy:
+      fail-fast: false
       matrix:
         revit-version: ['2021', '2022', '2023', '2024', '2025', '2026']
 
@@ -25,23 +26,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup .NET 8 SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v2
 
-      - name: Setup NuGet
-        uses: NuGet/setup-nuget@v2
-
-      - name: Restore NuGet packages
-        run: nuget restore Tools28.csproj -PackagesDirectory packages
-
       - name: Build for Revit ${{ matrix.revit-version }}
         run: |
-          msbuild Tools28.csproj `
-            /p:Configuration=Release `
-            /p:RevitVersion=${{ matrix.revit-version }} `
-            /p:Platform=AnyCPU `
-            /restore `
-            /v:minimal
+          dotnet build Tools28.csproj `
+            -c Release `
+            /p:RevitVersion=${{ matrix.revit-version }}
 
       - name: Create package
         shell: pwsh

--- a/Tools28.csproj
+++ b/Tools28.csproj
@@ -1,51 +1,26 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  
+<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{E40A22D9-DD80-4387-BA5D-8F9E4DF157D6}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <!-- デフォルトのRevitバージョン（ビルド時に /p:RevitVersion=20XX で上書き） -->
+    <RevitVersion Condition="'$(RevitVersion)' == ''">2024</RevitVersion>
+
+    <!-- Revit 2021-2024: .NET Framework 4.8 / Revit 2025-2026: .NET 8 -->
+    <TargetFramework Condition="'$(RevitVersion)' &lt; '2025'">net48</TargetFramework>
+    <TargetFramework Condition="'$(RevitVersion)' &gt;= '2025'">net8.0-windows</TargetFramework>
+
+    <UseWPF>true</UseWPF>
     <RootNamespace>Tools28</RootNamespace>
     <AssemblyName>Tools28</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    
-    <!-- デフォルトのRevitバージョン（環境変数で上書き可能） -->
-    <RevitVersion Condition="'$(RevitVersion)' == ''">2024</RevitVersion>
-  </PropertyGroup>
+    <ProjectGuid>{E40A22D9-DD80-4387-BA5D-8F9E4DF157D6}</ProjectGuid>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 
-  <!-- バージョン別の出力パス設定 -->
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\Revit$(RevitVersion)\</OutputPath>
-    <DefineConstants>DEBUG;TRACE;REVIT$(RevitVersion)</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\Revit$(RevitVersion)\</OutputPath>
-    <DefineConstants>TRACE;REVIT$(RevitVersion)</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
+    <!-- 出力先: bin\Release\Revit20XX\ -->
+    <OutputPath>bin\$(Configuration)\Revit$(RevitVersion)\</OutputPath>
 
-  <!-- WPF参照 -->
-  <ItemGroup>
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xaml" />
-    <Reference Include="WindowsBase" />
-  </ItemGroup>
+    <!-- 条件付きコンパイルシンボル -->
+    <DefineConstants>$(DefineConstants);REVIT$(RevitVersion)</DefineConstants>
+  </PropertyGroup>
 
   <!-- Revit API (NuGet パッケージ経由 - ローカル Revit 不要) -->
   <ItemGroup>
@@ -55,29 +30,6 @@
     <PackageReference Include="Nice3point.Revit.Api.RevitAPIUI" Version="$(RevitVersion).*">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-  </ItemGroup>
-
-  <!-- ソースファイル -->
-  <ItemGroup>
-    <Compile Include="Application.cs" />
-    <Compile Include="Commands\GridBubble\GridBubbleCommands.cs" />
-    <Compile Include="Commands\ViewCopy\ViewCopyCommands.cs" />
-    <Compile Include="Commands\SectionBoxCopy\SectionBoxCopyCommands.cs" />
-    <Compile Include="Commands\ViewportPosition\ViewportPositionCommands.cs" />
-    <Compile Include="Commands\CropBoxCopy\CropBoxCopyCommands.cs" />
-    <Compile Include="Commands\SheetCreation\SheetCreationCommands.cs" />
-    <Compile Include="Commands\SheetCreation\SheetCreationDialog.xaml.cs">
-      <DependentUpon>SheetCreationDialog.xaml</DependentUpon>
-    </Compile>
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-
-  <!-- XAMLファイル -->
-  <ItemGroup>
-    <Page Include="Commands\SheetCreation\SheetCreationDialog.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
   </ItemGroup>
 
   <!-- リソースファイル -->
@@ -96,5 +48,4 @@
     <Resource Include="Resources\Icons\cropbox_paste_32.png" />
   </ItemGroup>
 
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
…pport

- Tools28.csproj: Convert to SDK-style project format
  - Revit 2021-2024: targets net48 (.NET Framework 4.8)
  - Revit 2025-2026: targets net8.0-windows (.NET 8)
  - UseWPF for XAML dialog support
  - Auto-include .cs files (SDK-style default)
- build-and-release.yml:
  - Add .NET 8 SDK setup step
  - Use 'dotnet build' instead of msbuild for SDK-style compatibility
  - Add fail-fast: false so one version failure doesn't cancel others

https://claude.ai/code/session_01A5Hrnq6UvmTpcQDyNP1VjA