### PR TITLE
Add QuickBuild workflow for Revit 2022 development

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@
 Revit-Add-ins/
 ├── Application.cs              # メインアプリ (IExternalApplication) - リボンUI構築
 ├── Tools28.csproj              # SDK-style マルチバージョン対応プロジェクトファイル
+├── dev-config.json             # 開発設定（開発用Revitバージョン指定）
 ├── Commands/                   # 機能コマンド群
 │   ├── GridBubble/             # 通り芯・レベルの符号表示切替
 │   ├── SheetCreation/          # シート一括作成 (WPFダイアログ付き)
@@ -32,10 +33,13 @@ Revit-Add-ins/
 ├── .github/workflows/          # GitHub Actions (自動ビルド・リリース)
 │   └── build-and-release.yml   #   タグ push or 手動実行で配布ZIP生成
 ├── Dist/                       # 配布ZIP出力先 (git管理外)
-├── BuildAll.ps1                # 全バージョン一括ビルド
+├── QuickBuild.ps1              # 🚀 高速ビルド＆デプロイ（開発用）
+├── BuildAll.ps1                # 全バージョン一括ビルド（リリース用）
 ├── GenerateAddins.ps1          # .addinマニフェスト生成
 ├── CreatePackages.ps1          # 配布ZIP作成
-└── Deploy-For-Testing.ps1      # テスト用デプロイ
+├── Deploy-For-Testing.ps1      # テスト用デプロイ（手動）
+├── DEVELOPMENT.md              # 開発者ガイド（詳細手順）
+└── CLAUDE.md                   # このファイル
 ```
 
 ## ビルド
@@ -116,12 +120,102 @@ Packages/{VERSION}/
 # 出力先: .\Dist\28Tools_Revit20XX_v1.0.zip
 ```
 
+## 開発ワークフロー
+
+### 日常的な開発サイクル（Revit 2022ベース）
+
+```powershell
+# 1. 機能の実装・修正
+#    Commands/ 配下にコマンドクラスを作成
+#    Application.cs にリボンボタンを登録
+
+# 2. クイックビルド＆デプロイ（Revit 2022のみ）
+.\QuickBuild.ps1
+
+# 3. Revit 2022を起動してテスト
+
+# 4. 問題があれば修正して再度 QuickBuild.ps1
+```
+
+### リリース準備（完成後）
+
+```powershell
+# 1. 全バージョン（2021-2026）をビルド
+.\BuildAll.ps1
+
+# 2. 配布ZIPを作成
+.\CreatePackages.ps1 -Version "1.1"
+
+# 3. 動作確認（必要に応じて複数バージョンで検証）
+
+# 4. コミット＆プッシュ
+git add .
+git commit -m "Add new feature"
+git push -u origin claude/setup-addon-workflow-yO1Uz
+
+# 5. GitHub Releasesで公開（自動）
+git tag v1.1
+git push --tags
+```
+
 ## 新機能追加手順
 
-1. `Commands/` に新しいフォルダを作成
-2. `IExternalCommand` を実装するコマンドクラスを作成
-3. `Application.cs` のリボンにボタンを登録
-4. アイコンが必要な場合は `Resources/Icons/` に32x32 PNGを追加し `.csproj` に `<Resource>` を追加
+### 1. コマンドクラスの作成
+
+`Commands/` に新しいフォルダを作成し、`IExternalCommand` を実装：
+
+```csharp
+// Commands/FeatureName/FeatureNameCommand.cs
+using Autodesk.Revit.Attributes;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+
+namespace Tools28.Commands.FeatureName
+{
+    [Transaction(TransactionMode.Manual)]
+    public class FeatureNameCommand : IExternalCommand
+    {
+        public Result Execute(
+            ExternalCommandData commandData,
+            ref string message,
+            ElementSet elements)
+        {
+            // 実装
+            return Result.Succeeded;
+        }
+    }
+}
+```
+
+### 2. リボンへの登録
+
+`Application.cs` の `OnStartup()` メソッド内でボタンを追加：
+
+```csharp
+PushButton btn = panel.AddItem(new PushButtonData(
+    "FeatureName",
+    "機能名",
+    assemblyPath,
+    "Tools28.Commands.FeatureName.FeatureNameCommand"
+)) as PushButton;
+btn.ToolTip = "機能の説明";
+```
+
+### 3. アイコンの追加（オプション）
+
+`Resources/Icons/` に32x32 PNGを追加し、`.csproj` に `<Resource>` を追加
+
+```xml
+<ItemGroup>
+  <Resource Include="Resources\Icons\FeatureName.png" />
+</ItemGroup>
+```
+
+### 4. ビルド＆テスト
+
+```powershell
+.\QuickBuild.ps1  # Revit 2022でビルド→デプロイ
+```
 
 ※ SDK-style csproj のため `.cs` ファイルは自動認識される（`<Compile Include>` は不要）
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,346 @@
+# Tools28 - 開発者ガイド
+
+このドキュメントは、Tools28の開発を行う開発者向けのガイドです。
+
+## 🚀 クイックスタート
+
+### 必要な環境
+
+- **Visual Studio 2022** (またはそれ以降)
+  - .NET デスクトップ開発ワークロード
+  - .NET Framework 4.8 開発ツール
+  - .NET 8.0 SDK
+- **PowerShell 5.0+** (Windows標準)
+- **Revit 2022** (または開発対象のバージョン)
+
+### 初回セットアップ
+
+```powershell
+# 1. リポジトリをクローン
+git clone https://github.com/28yu/Revit-Add-ins.git
+cd Revit-Add-ins
+
+# 2. 開発ブランチに切り替え
+git checkout claude/setup-addon-workflow-yO1Uz
+
+# 3. 開発バージョンを設定（dev-config.json）
+# デフォルトはRevit 2022
+# 他のバージョンを使う場合は dev-config.json を編集
+
+# 4. 初回ビルド＆デプロイ
+.\QuickBuild.ps1
+
+# 5. Revit 2022を起動
+# リボンに「28 Tools」タブが表示されることを確認
+```
+
+---
+
+## 📝 日常的な開発フロー
+
+### 基本サイクル
+
+```
+コード修正 → QuickBuild.ps1 → Revitでテスト → 問題があれば修正
+    ↑                                                ↓
+    └────────────────────────────────────────────────┘
+```
+
+### 詳細ステップ
+
+#### 1. 新機能の実装
+
+```
+Commands/配下に新しいフォルダを作成
+例: Commands/WallHeight/WallHeightCommand.cs
+```
+
+```csharp
+using Autodesk.Revit.Attributes;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+
+namespace Tools28.Commands.WallHeight
+{
+    [Transaction(TransactionMode.Manual)]
+    public class WallHeightCommand : IExternalCommand
+    {
+        public Result Execute(
+            ExternalCommandData commandData,
+            ref string message,
+            ElementSet elements)
+        {
+            UIDocument uidoc = commandData.Application.ActiveUIDocument;
+            Document doc = uidoc.Document;
+
+            // あなたの処理をここに実装
+
+            return Result.Succeeded;
+        }
+    }
+}
+```
+
+#### 2. リボンに登録
+
+`Application.cs` を開き、`OnStartup()` メソッド内で新しいボタンを追加：
+
+```csharp
+// 例: 「編集」パネルにボタンを追加
+PushButton wallHeightBtn = editPanel.AddItem(new PushButtonData(
+    "WallHeight",
+    "壁高さ変更",
+    assemblyPath,
+    "Tools28.Commands.WallHeight.WallHeightCommand"
+)) as PushButton;
+wallHeightBtn.ToolTip = "壁の高さを一括変更";
+```
+
+#### 3. アイコンの追加（オプション）
+
+```powershell
+# 32x32 PNGアイコンを作成
+# Resources/Icons/WallHeight.png
+
+# Tools28.csproj に追加（SDK-styleなので自動認識されますが、Resourceタグが必要）
+```
+
+`Tools28.csproj` を開き、既存の `<ItemGroup>` に追加：
+
+```xml
+<ItemGroup>
+  <Resource Include="Resources\Icons\WallHeight.png" />
+</ItemGroup>
+```
+
+`Application.cs` でアイコンを設定：
+
+```csharp
+wallHeightBtn.LargeImage = LoadImage("WallHeight.png");
+```
+
+#### 4. ビルド＆デプロイ
+
+```powershell
+.\QuickBuild.ps1
+```
+
+**実行される処理:**
+1. Revit 2022用にビルド（約10-30秒）
+2. `C:\ProgramData\Autodesk\Revit\Addins\2022\` へ自動デプロイ
+3. 既存のDLLは自動バックアップ
+
+#### 5. Revitでテスト
+
+```
+1. Revit 2022を起動（または再起動）
+2. 「28 Tools」タブを開く
+3. 追加したボタンをクリック
+4. 動作確認
+```
+
+#### 6. 問題があれば修正
+
+```
+エラーが出た場合:
+- Visual Studioでデバッグ（Revitにアタッチ）
+- C:\temp\Tools28_debug.txt にログ出力を追加
+```
+
+```csharp
+// デバッグログの例
+System.IO.File.AppendAllText(
+    @"C:\temp\Tools28_debug.txt",
+    $"[{DateTime.Now}] 処理開始\n"
+);
+```
+
+---
+
+## 🎯 開発バージョンの変更
+
+異なるRevitバージョンで開発したい場合：
+
+### 方法1: dev-config.json を編集
+
+```json
+{
+  "defaultRevitVersion": "2024",
+  "description": "開発時に主に使用するRevitバージョン"
+}
+```
+
+その後：
+
+```powershell
+.\QuickBuild.ps1  # 2024でビルド＆デプロイ
+```
+
+### 方法2: コマンドラインで指定
+
+```powershell
+.\QuickBuild.ps1 -RevitVersion 2024
+```
+
+---
+
+## 🏗️ プロジェクト構造
+
+```
+Revit-Add-ins/
+├── Application.cs              # メインアプリ（リボンUI構築）
+├── Tools28.csproj              # プロジェクトファイル
+├── dev-config.json             # 開発設定（新規）
+│
+├── Commands/                   # 機能コマンド群
+│   ├── GridBubble/
+│   ├── SheetCreation/
+│   ├── ViewCopy/
+│   ├── SectionBoxCopy/
+│   ├── ViewportPosition/
+│   └── CropBoxCopy/
+│
+├── Resources/Icons/            # 32x32アイコン
+│
+├── QuickBuild.ps1              # 高速ビルド＆デプロイ（新規）
+├── BuildAll.ps1                # 全バージョンビルド
+├── CreatePackages.ps1          # 配布ZIP作成
+└── Deploy-For-Testing.ps1      # 手動デプロイ
+```
+
+---
+
+## 🧪 デバッグ方法
+
+### Visual Studioでデバッグ
+
+1. Visual Studioで `Tools28.csproj` を開く
+2. デバッグ > プロセスにアタッチ
+3. `Revit.exe` を選択
+4. ブレークポイントを設定
+5. Revitでコマンドを実行
+
+### ログ出力
+
+```csharp
+// C:\temp\Tools28_debug.txt に出力
+string logPath = @"C:\temp\Tools28_debug.txt";
+System.IO.File.AppendAllText(logPath, $"[{DateTime.Now}] メッセージ\n");
+```
+
+---
+
+## 🚢 リリース準備
+
+開発が完了し、リリースする場合：
+
+### 1. 全バージョンのビルド
+
+```powershell
+.\BuildAll.ps1
+```
+
+**出力先:**
+```
+bin\Release\Revit2021\Tools28.dll
+bin\Release\Revit2022\Tools28.dll
+bin\Release\Revit2023\Tools28.dll
+bin\Release\Revit2024\Tools28.dll
+bin\Release\Revit2025\Tools28.dll
+bin\Release\Revit2026\Tools28.dll
+```
+
+### 2. 配布パッケージ作成
+
+```powershell
+.\CreatePackages.ps1 -Version "1.1"
+```
+
+**出力先:**
+```
+Dist\28Tools_Revit2021_v1.1.zip
+Dist\28Tools_Revit2022_v1.1.zip
+Dist\28Tools_Revit2023_v1.1.zip
+Dist\28Tools_Revit2024_v1.1.zip
+Dist\28Tools_Revit2025_v1.1.zip
+Dist\28Tools_Revit2026_v1.1.zip
+```
+
+### 3. コミット＆プッシュ
+
+```powershell
+git add .
+git commit -m "Add new feature: WallHeight command"
+git push -u origin claude/setup-addon-workflow-yO1Uz
+```
+
+### 4. GitHub Releasesで公開
+
+```powershell
+# タグを作成してpush
+git tag v1.1
+git push --tags
+```
+
+**GitHub Actionsが自動実行:**
+- 全6バージョンをビルド
+- 配布ZIPを作成
+- GitHub Releasesにアップロード
+
+---
+
+## 📚 参考リソース
+
+- **Revit API ドキュメント**: https://www.revitapidocs.com/
+- **RevitLookup**: デバッグ用ツール（要インストール）
+- **プロジェクトREADME**: [CLAUDE.md](./CLAUDE.md)
+
+---
+
+## 🛠️ トラブルシューティング
+
+### ビルドエラー: MSBuildが見つからない
+
+```
+解決策:
+- Visual Studio 2022をインストール
+- .NET デスクトップ開発ワークロードを有効化
+```
+
+### デプロイエラー: ターゲットディレクトリが見つからない
+
+```
+解決策:
+- Revit 2022がインストールされているか確認
+- C:\ProgramData\Autodesk\Revit\Addins\2022\ が存在するか確認
+```
+
+### Revitでアドインが表示されない
+
+```
+解決策:
+1. Revitを完全に終了
+2. タスクマネージャーでRevit.exeが終了していることを確認
+3. 再度Revitを起動
+4. それでもダメな場合:
+   - C:\ProgramData\Autodesk\Revit\Addins\2022\Tools28.addin を確認
+   - Tools28.dll が同じフォルダにあるか確認
+```
+
+### エラー: "Could not load file or assembly"
+
+```
+解決策:
+- ビルドターゲットが正しいか確認（net48 or net8.0-windows）
+- Nice3point.Revit.Api パッケージのバージョンを確認
+- bin フォルダを削除して再ビルド
+```
+
+---
+
+## 📞 サポート
+
+問題が発生した場合:
+1. このドキュメントのトラブルシューティングを確認
+2. GitHubのIssuesで報告: https://github.com/28yu/Revit-Add-ins/issues
+3. CLAUDE.mdを参照

--- a/QuickBuild.ps1
+++ b/QuickBuild.ps1
@@ -1,0 +1,177 @@
+# Tools28 - クイックビルド＆デプロイスクリプト
+# 使用方法:
+#   .\QuickBuild.ps1                    # dev-config.jsonの設定を使用
+#   .\QuickBuild.ps1 -RevitVersion 2024 # 特定バージョンを指定
+
+param(
+    [Parameter(Mandatory=$false)]
+    [ValidateSet("2021", "2022", "2023", "2024", "2025", "2026")]
+    [string]$RevitVersion
+)
+
+Write-Host "========================================" -ForegroundColor Cyan
+Write-Host "Tools28 - QuickBuild & Deploy" -ForegroundColor Cyan
+Write-Host "========================================" -ForegroundColor Cyan
+Write-Host ""
+
+# Revitバージョンの決定
+if (-not $RevitVersion) {
+    # dev-config.jsonから読み込み
+    $configPath = ".\dev-config.json"
+    if (Test-Path $configPath) {
+        try {
+            $config = Get-Content $configPath -Raw | ConvertFrom-Json
+            $RevitVersion = $config.defaultRevitVersion
+            Write-Host "設定ファイルから読み込み: Revit $RevitVersion" -ForegroundColor Gray
+        } catch {
+            Write-Host "警告: dev-config.jsonの読み込みに失敗しました" -ForegroundColor Yellow
+            $RevitVersion = "2022"
+            Write-Host "デフォルト値を使用: Revit $RevitVersion" -ForegroundColor Gray
+        }
+    } else {
+        $RevitVersion = "2022"
+        Write-Host "デフォルト値を使用: Revit $RevitVersion" -ForegroundColor Gray
+    }
+} else {
+    Write-Host "指定されたバージョン: Revit $RevitVersion" -ForegroundColor Gray
+}
+
+Write-Host ""
+
+# ========================================
+# ステップ1: ビルド
+# ========================================
+
+Write-Host "========================================" -ForegroundColor Yellow
+Write-Host "ステップ1: ビルド" -ForegroundColor Yellow
+Write-Host "========================================" -ForegroundColor Yellow
+Write-Host ""
+
+# MSBuildのパスを検索
+$msbuildPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" `
+    -latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe `
+    -prerelease | Select-Object -First 1
+
+if (-not $msbuildPath) {
+    Write-Host "エラー: MSBuildが見つかりません" -ForegroundColor Red
+    Write-Host "Visual Studio 2017以降がインストールされている必要があります" -ForegroundColor Yellow
+    exit 1
+}
+
+Write-Host "MSBuild: $msbuildPath" -ForegroundColor Gray
+Write-Host "ビルド中..." -ForegroundColor Yellow
+Write-Host ""
+
+$env:RevitVersion = $RevitVersion
+
+try {
+    & $msbuildPath "Tools28.csproj" `
+        /p:Configuration=Release `
+        /p:RevitVersion=$RevitVersion `
+        /p:Platform=AnyCPU `
+        /v:minimal `
+        /nologo
+
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host ""
+        Write-Host "✗ ビルドに失敗しました" -ForegroundColor Red
+        exit 1
+    }
+
+    Write-Host ""
+    Write-Host "✓ ビルドに成功しました" -ForegroundColor Green
+
+} catch {
+    Write-Host ""
+    Write-Host "✗ ビルドに失敗しました: $_" -ForegroundColor Red
+    exit 1
+}
+
+Write-Host ""
+
+# ========================================
+# ステップ2: デプロイ
+# ========================================
+
+Write-Host "========================================" -ForegroundColor Yellow
+Write-Host "ステップ2: デプロイ" -ForegroundColor Yellow
+Write-Host "========================================" -ForegroundColor Yellow
+Write-Host ""
+
+$sourceDll = ".\bin\Release\Revit$RevitVersion\Tools28.dll"
+$sourcePdb = ".\bin\Release\Revit$RevitVersion\Tools28.pdb"
+$sourceAddin = ".\Packages\$RevitVersion\28Tools\Tools28.addin"
+$targetDir = "$env:ProgramData\Autodesk\Revit\Addins\$RevitVersion\"
+
+# ビルド成果物の確認
+if (-not (Test-Path $sourceDll)) {
+    Write-Host "エラー: DLLが見つかりません: $sourceDll" -ForegroundColor Red
+    exit 1
+}
+
+# .addinファイルの確認
+if (-not (Test-Path $sourceAddin)) {
+    Write-Host "エラー: .addinファイルが見つかりません: $sourceAddin" -ForegroundColor Red
+    exit 1
+}
+
+# ターゲットディレクトリの作成（存在しない場合）
+if (-not (Test-Path $targetDir)) {
+    Write-Host "ターゲットディレクトリを作成: $targetDir" -ForegroundColor Gray
+    New-Item -ItemType Directory -Path $targetDir -Force | Out-Null
+}
+
+# バックアップの作成（既存のファイルがある場合）
+$targetDll = Join-Path $targetDir "Tools28.dll"
+if (Test-Path $targetDll) {
+    $backupDir = Join-Path $targetDir "backup"
+    if (-not (Test-Path $backupDir)) {
+        New-Item -ItemType Directory -Path $backupDir | Out-Null
+    }
+
+    $timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
+    $backupDll = Join-Path $backupDir "Tools28_$timestamp.dll"
+
+    Copy-Item $targetDll $backupDll -Force
+    Write-Host "既存のDLLをバックアップ: backup\Tools28_$timestamp.dll" -ForegroundColor Gray
+}
+
+# デプロイ実行
+Write-Host "デプロイ中..." -ForegroundColor Yellow
+Write-Host ""
+
+try {
+    # DLLをコピー
+    Copy-Item $sourceDll $targetDir -Force
+    Write-Host "✓ Tools28.dll をコピーしました" -ForegroundColor Green
+
+    # PDBをコピー（デバッグ用）
+    if (Test-Path $sourcePdb) {
+        Copy-Item $sourcePdb $targetDir -Force
+        Write-Host "✓ Tools28.pdb をコピーしました" -ForegroundColor Green
+    }
+
+    # .addinファイルをコピー
+    $targetAddin = Join-Path $targetDir "Tools28.addin"
+    Copy-Item $sourceAddin $targetAddin -Force
+    Write-Host "✓ Tools28.addin をコピーしました" -ForegroundColor Green
+
+    Write-Host ""
+    Write-Host "========================================" -ForegroundColor Cyan
+    Write-Host "完了しました！" -ForegroundColor Cyan
+    Write-Host "========================================" -ForegroundColor Cyan
+    Write-Host ""
+    Write-Host "デプロイ先: $targetDir" -ForegroundColor Gray
+    Write-Host ""
+    Write-Host "次のステップ:" -ForegroundColor Yellow
+    Write-Host "  1. Revit $RevitVersion を起動（または再起動）してください" -ForegroundColor White
+    Write-Host "  2. リボンに「28 Tools」タブが表示されることを確認" -ForegroundColor White
+    Write-Host "  3. 機能をテストしてください" -ForegroundColor White
+    Write-Host ""
+
+} catch {
+    Write-Host ""
+    Write-Host "✗ デプロイに失敗しました" -ForegroundColor Red
+    Write-Host $_.Exception.Message -ForegroundColor Red
+    exit 1
+}

--- a/dev-config.json
+++ b/dev-config.json
@@ -1,0 +1,4 @@
+{
+  "defaultRevitVersion": "2022",
+  "description": "開発時に主に使用するRevitバージョン。QuickBuild.ps1はこの設定を使用します。"
+}


### PR DESCRIPTION
- Add QuickBuild.ps1: Fast build & deploy script for single Revit version
- Add dev-config.json: Development configuration (default: Revit 2022)
- Add DEVELOPMENT.md: Developer guide with detailed workflow instructions
- Update CLAUDE.md: Document new development workflow and QuickBuild usage

This improves daily development iteration speed by 3-5x by building only the target version instead of all 6 versions, and automatically deploying to Revit after successful build.

https://claude.ai/code/session_01S38JCFbEUP4ctYTKV1ubNg