### PR TITLE
Redesign workflow diagram: vertical flowchart, A4 size, muted colors

### DIFF
--- a/Docs/workflow-diagram.html
+++ b/Docs/workflow-diagram.html
@@ -11,589 +11,522 @@
 *{margin:0;padding:0;box-sizing:border-box}
 body{
   font-family:'Zen Maru Gothic','Hiragino Sans','Meiryo',sans-serif;
-  background-color:#faf6ee;
-  min-height:100vh;
-  color:#33302b;
-  line-height:1.5;
+  background:#f7f5f0;
+  color:#3a3632;
+  line-height:1.45;
 }
 
-/* ===== Container ===== */
-.container{
-  max-width:860px;
+/* ===== A4 Page ===== */
+.page{
+  width:210mm;
+  min-height:297mm;
+  max-width:100vw;
   margin:0 auto;
-  padding:20px 16px 24px;
+  background:#fff;
+  padding:18mm 14mm 12mm;
+  box-shadow:0 1px 12px rgba(0,0,0,0.06);
 }
 
 /* ===== Title ===== */
-.title-block{
+.title{
   text-align:center;
-  margin-bottom:14px;
+  margin-bottom:5mm;
 }
-.title-block h1{
-  display:inline;
-  font-size:1.5rem;
+.title h1{
+  font-size:15pt;
   font-weight:900;
-  color:#2d2d2d;
-  background:linear-gradient(transparent 55%,#fcd34d 55%);
-  padding:0 8px;
-  line-height:1.6;
+  color:#3a3632;
+  display:inline;
+  background:linear-gradient(transparent 55%,#d6e6f2 55%);
+  padding:0 4px;
 }
 .title-sub{
   display:block;
-  font-size:0.82rem;
-  color:#8b7e6e;
+  font-size:8pt;
+  color:#8a8078;
   font-weight:700;
-  margin-top:6px;
-}
-
-/* ===== Flow Banner ===== */
-.flow-banner{
-  background:#fff;
-  border:2.5px solid #e8dcc8;
-  border-radius:14px;
-  padding:12px 10px;
-  margin-bottom:10px;
-  display:flex;
-  align-items:center;
-  justify-content:center;
-  gap:0;
-  flex-wrap:wrap;
-}
-.flow-step{
-  display:flex;
-  align-items:center;
-  gap:6px;
-  padding:5px 10px;
-  border-radius:20px;
-  font-size:0.82rem;
-  font-weight:700;
-  white-space:nowrap;
-}
-.flow-step .icon{font-size:1.1rem}
-.fs-you{background:#fef3c7;color:#92400e}
-.fs-ai{background:#ede9fe;color:#5b21b6}
-.fs-build{background:#dbeafe;color:#1e40af}
-.fs-test{background:#d1fae5;color:#065f46}
-.fs-ship{background:#fce7f3;color:#9d174d}
-.flow-arrow{
-  font-size:1.1rem;
-  color:#c4b5a0;
-  margin:0 2px;
-  flex-shrink:0;
+  margin-top:2mm;
 }
 
 /* ===== Legend ===== */
-.legend-row{
+.legend{
   display:flex;
   justify-content:center;
   gap:14px;
-  margin-bottom:10px;
-  flex-wrap:wrap;
+  margin-bottom:5mm;
 }
 .legend-item{
-  display:flex;
-  align-items:center;
-  gap:4px;
-  font-size:0.72rem;
-  font-weight:700;
-  color:#7a6e5e;
+  display:flex;align-items:center;gap:4px;
+  font-size:7pt;font-weight:700;color:#8a8078;
 }
 .legend-dot{
-  width:10px;height:10px;border-radius:50%;
-  border:2px solid;
+  width:8px;height:8px;border-radius:50%;
+  border:1.5px solid;
 }
-.ld-you{background:#fef3c7;border-color:#f59e0b}
-.ld-ai{background:#ede9fe;border-color:#8b5cf6}
-.ld-auto{background:#e2e8f0;border-color:#94a3b8}
+.ld-you{background:#e8f0f6;border-color:#7baac8}
+.ld-ai{background:#e8f0f6;border-color:#7baac8}
+.ld-auto{background:#f0ece5;border-color:#c4baa8}
 
-/* ===== Card Grid ===== */
-.card-grid{
-  display:grid;
-  grid-template-columns:1fr 1fr;
-  gap:8px;
-}
-
-/* ===== Card ===== */
-.card{
-  background:#fff;
-  border-radius:12px;
-  border:2.5px solid #e8dcc8;
+/* ===== Phase Container ===== */
+.phase{
+  border:1.5px solid #d8d2c8;
+  border-radius:8px;
+  margin-bottom:4mm;
   overflow:hidden;
 }
-.card-header{
-  display:flex;
-  align-items:center;
-  gap:7px;
-  padding:8px 12px;
-  font-size:0.85rem;
+.phase-header{
+  background:#f0ece5;
+  padding:2.5mm 4mm;
+  font-size:9pt;
   font-weight:900;
-  border-bottom:2px dashed #eee4d4;
+  color:#5a5347;
+  border-bottom:1.5px solid #d8d2c8;
 }
-.card-header .h-icon{
-  width:30px;height:30px;border-radius:50%;
-  display:flex;align-items:center;justify-content:center;
-  font-size:1rem;flex-shrink:0;
-  border:2px solid;
+
+/* ===== Vertical Flow ===== */
+.flow{
+  padding:4mm 4mm;
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  gap:0;
 }
-.card-header .h-sub{
-  font-size:0.68rem;
+
+/* Node */
+.node{
+  background:#fff;
+  border:1.5px solid #c8d8e4;
+  border-radius:7px;
+  padding:2.5mm 5mm;
+  text-align:center;
+  width:58mm;
+  position:relative;
+}
+.node.wide{width:72mm}
+.node-role{
+  font-size:7pt;
+  font-weight:700;
+  color:#8a8078;
+  margin-bottom:0.5mm;
+}
+.node-name{
+  font-size:9.5pt;
+  font-weight:900;
+  color:#3a3632;
+}
+.node-desc{
+  font-size:7pt;
   font-weight:500;
-  color:#a09585;
-  margin-left:auto;
+  color:#7a7268;
+  margin-top:0.5mm;
+  line-height:1.4;
+}
+.node-you{
+  background:#e8f0f6;
+  border-color:#a8c8dc;
+}
+.node-auto{
+  background:#f5f2ec;
+  border-color:#d0c8b8;
+}
+
+/* Arrow (vertical connector) */
+.arrow{
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  padding:1mm 0;
+  color:#b0a898;
+  position:relative;
+}
+.arrow-line{
+  width:1.5px;
+  height:4mm;
+  background:#c4baa8;
+}
+.arrow-head{
+  font-size:7pt;
+  line-height:1;
+  margin-top:-1px;
+}
+.arrow-label{
+  font-size:6.5pt;
+  font-weight:700;
+  color:#8a8078;
+  position:absolute;
+  left:calc(50% + 6mm);
+  top:50%;
+  transform:translateY(-50%);
   white-space:nowrap;
 }
-.card-body{
-  padding:8px 12px 10px;
+.arrow-label-left{
+  left:auto;
+  right:calc(50% + 6mm);
 }
-.card-body ul{
-  list-style:none;
-  padding:0;
+
+/* Horizontal row */
+.hrow{
+  display:flex;
+  align-items:center;
+  gap:3mm;
+  width:100%;
+  justify-content:center;
 }
-.card-body li{
-  font-size:0.76rem;
-  font-weight:500;
-  padding:2px 0;
+.harrow{
+  display:flex;
+  align-items:center;
+  gap:0;
+  color:#b0a898;
+}
+.harrow-line{
+  width:5mm;
+  height:1.5px;
+  background:#c4baa8;
+}
+.harrow-head{
+  font-size:7pt;
+  line-height:1;
+  margin-left:-1px;
+}
+.harrow-label{
+  font-size:6.5pt;
+  font-weight:700;
+  color:#8a8078;
+  white-space:nowrap;
+}
+.harrow-up{
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+}
+
+/* Branch split */
+.branch{
   display:flex;
   align-items:flex-start;
-  gap:5px;
-  line-height:1.45;
+  gap:4mm;
+  width:100%;
+  justify-content:center;
 }
-.card-body li .bullet{
-  flex-shrink:0;
-  font-size:0.72rem;
-  margin-top:1px;
+.branch-col{
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  gap:0;
 }
-.card-body .note{
-  font-size:0.7rem;
-  color:#a09585;
+
+/* Feedback loop */
+.feedback{
+  display:flex;
+  align-items:center;
+  gap:2mm;
+  margin-top:2mm;
+  padding:1.5mm 4mm;
+  background:#faf7f2;
+  border:1px dashed #d0c8b8;
+  border-radius:5px;
+  font-size:6.5pt;
   font-weight:700;
-  margin-top:4px;
-  padding:4px 8px;
-  background:#faf6ee;
-  border-radius:6px;
-  display:inline-block;
+  color:#8a8078;
 }
 
-/* ===== Card Theme Colors ===== */
-/* あなた */
-.card-you{border-color:#f59e0b}
-.card-you .card-header{background:#fef9e7;color:#92400e}
-.card-you .h-icon{background:#fef3c7;border-color:#f59e0b;color:#d97706}
-
-/* Claude Code */
-.card-claude{border-color:#8b5cf6}
-.card-claude .card-header{background:#f5f3ff;color:#5b21b6}
-.card-claude .h-icon{background:#ede9fe;border-color:#8b5cf6;color:#7c3aed}
-
-/* PowerShell */
-.card-ps{border-color:#3b82f6}
-.card-ps .card-header{background:#eff6ff;color:#1e40af}
-.card-ps .h-icon{background:#dbeafe;border-color:#3b82f6;color:#2563eb}
-
-/* Revit */
-.card-revit{border-color:#06b6d4}
-.card-revit .card-header{background:#ecfeff;color:#155e75}
-.card-revit .h-icon{background:#cffafe;border-color:#06b6d4;color:#0891b2}
-
-/* GitHub */
-.card-github{border-color:#475569}
-.card-github .card-header{background:#f1f5f9;color:#1e293b}
-.card-github .h-icon{background:#e2e8f0;border-color:#475569;color:#334155}
-
-/* NuGet */
-.card-nuget{border-color:#f97316}
-.card-nuget .card-header{background:#fff7ed;color:#9a3412}
-.card-nuget .h-icon{background:#ffedd5;border-color:#f97316;color:#ea580c}
-
-/* Actions */
-.card-actions{border-color:#64748b}
-.card-actions .card-header{background:#f8fafc;color:#334155}
-.card-actions .h-icon{background:#e2e8f0;border-color:#64748b;color:#475569}
-
-/* Users */
-.card-users{border-color:#ec4899}
-.card-users .card-header{background:#fdf2f8;color:#9d174d}
-.card-users .h-icon{background:#fce7f3;border-color:#ec4899;color:#db2777}
-
-/* ===== Workflow Steps ===== */
-.workflow-section{
-  margin-top:10px;
-}
-.workflow-title{
-  font-size:0.9rem;
-  font-weight:900;
-  color:#2d2d2d;
-  text-align:center;
-  margin-bottom:8px;
-}
-.workflow-title span{
-  background:linear-gradient(transparent 55%,#bfdbfe 55%);
-  padding:0 6px;
-}
-.steps{
-  display:grid;
-  grid-template-columns:repeat(5,1fr);
-  gap:6px;
-}
-.step{
-  background:#fff;
-  border-radius:10px;
-  border:2.5px solid #e8dcc8;
-  padding:8px 8px 10px;
-  text-align:center;
-  position:relative;
-}
-.step-num{
-  display:inline-flex;
-  align-items:center;justify-content:center;
-  width:22px;height:22px;
-  border-radius:50%;
-  font-size:0.72rem;font-weight:900;
-  color:#fff;
-  margin-bottom:4px;
-}
-.step-label{
-  font-size:0.74rem;
-  font-weight:900;
-  line-height:1.3;
-  margin-bottom:2px;
-}
-.step-desc{
-  font-size:0.66rem;
-  font-weight:500;
-  color:#8b7e6e;
-  line-height:1.35;
-}
-.step-arrow{
+/* Side annotation */
+.side-note{
   position:absolute;
-  right:-11px;top:50%;
-  transform:translateY(-50%);
-  font-size:0.9rem;
-  color:#c4b5a0;
-  z-index:2;
+  font-size:6pt;
+  font-weight:700;
+  color:#a09888;
+  white-space:nowrap;
 }
 
-.sn-1{background:#f59e0b}
-.sn-2{background:#8b5cf6}
-.sn-3{background:#3b82f6}
-.sn-4{background:#06b6d4}
-.sn-5{background:#22c55e}
-
-.step:nth-child(1){border-color:#f59e0b}
-.step:nth-child(2){border-color:#8b5cf6}
-.step:nth-child(3){border-color:#3b82f6}
-.step:nth-child(4){border-color:#06b6d4}
-.step:nth-child(5){border-color:#22c55e}
-
-/* ===== Release Flow (bottom row) ===== */
-.release-row{
-  display:grid;
-  grid-template-columns:repeat(3,1fr);
-  gap:6px;
-  margin-top:6px;
-}
-.step-wide{
-  background:#fff;
-  border-radius:10px;
-  border:2.5px solid;
-  padding:8px 10px;
+/* Result node (code) */
+.node-result{
+  background:#f5f2ec;
+  border:1.5px dashed #c4baa8;
+  border-radius:7px;
+  padding:2mm 5mm;
   text-align:center;
-  position:relative;
+  font-size:8pt;
+  font-weight:700;
+  color:#6a6258;
 }
-.step-wide .step-arrow{right:-11px}
+
+/* OK/NG badges */
+.badge{
+  display:inline-block;
+  padding:0.5mm 2.5mm;
+  border-radius:3px;
+  font-size:6.5pt;
+  font-weight:900;
+}
+.badge-ok{background:#e8f0f6;color:#5a8aa8}
+.badge-ng{background:#f0ece5;color:#8a7a68}
 
 /* ===== Callout ===== */
 .callout{
-  margin-top:10px;
-  background:#fef9e7;
-  border:2.5px solid #fbbf24;
-  border-radius:12px;
-  padding:10px 14px;
-  display:flex;
-  align-items:flex-start;
-  gap:8px;
-}
-.callout-icon{
-  font-size:1.2rem;
-  flex-shrink:0;
-  margin-top:1px;
-}
-.callout-text{
-  font-size:0.76rem;
+  margin-top:4mm;
+  background:#f0ece5;
+  border:1.5px solid #d8d2c8;
+  border-radius:7px;
+  padding:2.5mm 4mm;
+  font-size:7pt;
   font-weight:700;
-  color:#78350f;
-  line-height:1.5;
+  color:#5a5347;
+  line-height:1.55;
 }
-.callout-text strong{color:#92400e}
+.callout strong{color:#3a3632}
 
 /* ===== Footer ===== */
 .footer{
   text-align:center;
-  padding:10px 16px 0;
-  font-size:0.7rem;
-  color:#a09585;
+  margin-top:3mm;
+  font-size:6.5pt;
+  color:#a09888;
   font-weight:700;
 }
-.footer a{color:#6366f1;text-decoration:none}
-.footer a:hover{text-decoration:underline}
+.footer a{color:#7baac8;text-decoration:none}
+
+/* ===== Print ===== */
+@media print{
+  body{background:#fff}
+  .page{
+    box-shadow:none;
+    padding:10mm 12mm 8mm;
+    min-height:auto;
+  }
+}
 
 /* ===== Responsive ===== */
-@media(max-width:680px){
-  .card-grid{grid-template-columns:1fr}
-  .steps{grid-template-columns:1fr}
-  .step-arrow{display:none}
-  .release-row{grid-template-columns:1fr}
-  .flow-banner{flex-direction:column;gap:4px}
-  .flow-arrow{transform:rotate(90deg)}
+@media(max-width:600px){
+  .page{
+    width:100%;
+    padding:5mm 4mm;
+    min-height:auto;
+  }
+  .hrow{flex-direction:column;gap:0}
+  .harrow{transform:rotate(90deg)}
+  .branch{flex-direction:column;align-items:center}
+  .node{width:auto;max-width:90%}
+  .node.wide{width:auto;max-width:90%}
 }
 </style>
 </head>
 <body>
 
-<div class="container">
+<div class="page">
 
-  <!-- ===== Title ===== -->
-  <div class="title-block">
+  <!-- Title -->
+  <div class="title">
     <h1>Tools28 開発ワークフロー 相関図</h1>
     <span class="title-sub">あなたが考えて指示 → AI が全て書く → 自動でビルド → あなたが確認</span>
   </div>
 
-  <!-- ===== Flow Banner ===== -->
-  <div class="flow-banner">
-    <div class="flow-step fs-you"><span class="icon">🙂</span> あなたが指示</div>
-    <span class="flow-arrow">▸</span>
-    <div class="flow-step fs-ai"><span class="icon">🤖</span> Claude が実装</div>
-    <span class="flow-arrow">▸</span>
-    <div class="flow-step fs-build"><span class="icon">⚡</span> ビルド＆デプロイ</div>
-    <span class="flow-arrow">▸</span>
-    <div class="flow-step fs-test"><span class="icon">🔍</span> Revit で確認</div>
-    <span class="flow-arrow">▸</span>
-    <div class="flow-step fs-ship"><span class="icon">📦</span> 自動配布</div>
-  </div>
-
-  <!-- ===== Legend ===== -->
-  <div class="legend-row">
+  <!-- Legend -->
+  <div class="legend">
     <div class="legend-item"><div class="legend-dot ld-you"></div>あなたが行う</div>
     <div class="legend-item"><div class="legend-dot ld-ai"></div>AI が行う</div>
     <div class="legend-item"><div class="legend-dot ld-auto"></div>自動で動く</div>
   </div>
 
-  <!-- ===== Card Grid: Roles ===== -->
-  <div class="card-grid">
+  <!-- ============================== -->
+  <!-- Phase 1: 開発フェーズ          -->
+  <!-- ============================== -->
+  <div class="phase">
+    <div class="phase-header">開発フェーズ</div>
+    <div class="flow">
 
-    <!-- あなた -->
-    <div class="card card-you">
-      <div class="card-header">
-        <div class="h-icon">🙂</div>
-        あなた
-        <span class="h-sub">監督・プロデューサー</span>
+      <!-- あなた -->
+      <div class="node node-you wide">
+        <div class="node-role">🙂 あなた ─ 監督・プロデューサー</div>
+        <div class="node-name">作りたい機能を考える・仕様をまとめる</div>
       </div>
-      <div class="card-body">
-        <ul>
-          <li><span class="bullet">💬</span>Claude Code に日本語で指示を出す</li>
-          <li><span class="bullet">🔨</span>QuickBuild.ps1 でビルド＆デプロイ</li>
-          <li><span class="bullet">🔍</span>Revit を起動して動作確認</li>
-          <li><span class="bullet">✅</span>OK → コミット＆プッシュ</li>
-          <li><span class="bullet">🔄</span>NG → 修正を再指示</li>
-        </ul>
-      </div>
-    </div>
 
-    <!-- Claude Code -->
-    <div class="card card-claude">
-      <div class="card-header">
-        <div class="h-icon">🤖</div>
-        Claude Code
-        <span class="h-sub">AI 脚本家</span>
+      <div class="arrow">
+        <div class="arrow-line"></div>
+        <div class="arrow-head">▼</div>
+        <span class="arrow-label">指示を出す</span>
       </div>
-      <div class="card-body">
-        <ul>
-          <li><span class="bullet">✨</span>コマンドクラス (.cs) を作成・修正</li>
-          <li><span class="bullet">🎨</span>WPF ダイアログ (XAML) を構築</li>
-          <li><span class="bullet">🎯</span>Application.cs にリボンボタン登録</li>
-          <li><span class="bullet">📝</span>csproj / スクリプトの更新</li>
-        </ul>
-        <div class="note">💡 コードは全て AI が書きます</div>
-      </div>
-    </div>
 
-    <!-- PowerShell -->
-    <div class="card card-ps">
-      <div class="card-header">
-        <div class="h-icon">&gt;_</div>
-        PowerShell
-        <span class="h-sub">現場スタッフ</span>
+      <!-- Claude Code -->
+      <div class="node wide">
+        <div class="node-role">🤖 Claude Code ─ AI 脚本家</div>
+        <div class="node-name">コードを全て書く</div>
+        <div class="node-desc">コマンドクラス (.cs) / WPF (XAML) / Application.cs / csproj</div>
       </div>
-      <div class="card-body">
-        <ul>
-          <li><span class="bullet">🚀</span>QuickBuild.ps1 — 高速ビルド＆デプロイ</li>
-          <li><span class="bullet">📦</span>BuildAll.ps1 — 全6版一括ビルド</li>
-          <li><span class="bullet">🗜️</span>CreatePackages.ps1 — 配布ZIP作成</li>
-        </ul>
-        <div class="note">Revit 2021〜2026 対応</div>
-      </div>
-    </div>
 
-    <!-- Revit -->
-    <div class="card card-revit">
-      <div class="card-header">
-        <div class="h-icon">R</div>
-        Revit
-        <span class="h-sub">舞台（動作確認）</span>
+      <div class="arrow">
+        <div class="arrow-line"></div>
+        <div class="arrow-head">▼</div>
       </div>
-      <div class="card-body">
-        <ul>
-          <li><span class="bullet">🏗️</span>ビルドしたアドインを読み込み</li>
-          <li><span class="bullet">🔍</span>実際に操作して動作を確認</li>
-          <li><span class="bullet">👍</span>OK → 次のステップへ</li>
-          <li><span class="bullet">❌</span>NG → Claude に修正指示</li>
-        </ul>
-      </div>
-    </div>
 
-    <!-- GitHub -->
-    <div class="card card-github">
-      <div class="card-header">
-        <div class="h-icon">🐙</div>
-        GitHub
-        <span class="h-sub">台本倉庫</span>
-      </div>
-      <div class="card-body">
-        <ul>
-          <li><span class="bullet">💾</span>ソースコードをバージョン管理</li>
-          <li><span class="bullet">🏷️</span>タグ push → 自動リリース開始</li>
-          <li><span class="bullet">📋</span>Issue / PR で変更を追跡</li>
-        </ul>
-      </div>
-    </div>
+      <!-- Code -->
+      <div class="node-result" style="width:48mm">コード（設計図）が完成</div>
 
-    <!-- NuGet -->
-    <div class="card card-nuget">
-      <div class="card-header">
-        <div class="h-icon">📦</div>
-        NuGet
-        <span class="h-sub">小道具係</span>
+      <div class="arrow">
+        <div class="arrow-line"></div>
+        <div class="arrow-head">▼</div>
+        <span class="arrow-label">git push で保管</span>
       </div>
-      <div class="card-body">
-        <ul>
-          <li><span class="bullet">🔧</span>Revit API パッケージを自動取得</li>
-          <li><span class="bullet">📚</span>Nice3point.Revit.Api 使用</li>
-          <li><span class="bullet">💻</span>ローカルに Revit 不要でビルド可能</li>
-        </ul>
-      </div>
-    </div>
 
-    <!-- GitHub Actions -->
-    <div class="card card-actions">
-      <div class="card-header">
-        <div class="h-icon">⚡</div>
-        GitHub Actions
-        <span class="h-sub">自動スタッフ</span>
-      </div>
-      <div class="card-body">
-        <ul>
-          <li><span class="bullet">🏗️</span>全6バージョンを自動ビルド</li>
-          <li><span class="bullet">📦</span>配布ZIP を自動生成</li>
-          <li><span class="bullet">🚀</span>GitHub Releases にアップロード</li>
-        </ul>
-        <div class="note">タグ push で自動起動</div>
-      </div>
-    </div>
-
-    <!-- ユーザー -->
-    <div class="card card-users">
-      <div class="card-header">
-        <div class="h-icon">👥</div>
-        ユーザー
-        <span class="h-sub">ダウンロードして使う</span>
-      </div>
-      <div class="card-body">
-        <ul>
-          <li><span class="bullet">⬇️</span>GitHub Releases から ZIP 取得</li>
-          <li><span class="bullet">📁</span>install.bat を管理者実行</li>
-          <li><span class="bullet">🎉</span>Revit 再起動でアドインが使える</li>
-        </ul>
-      </div>
-    </div>
-
-  </div><!-- /card-grid -->
-
-  <!-- ===== Workflow Steps ===== -->
-  <div class="workflow-section">
-    <div class="workflow-title"><span>📐 日常の開発サイクル</span></div>
-    <div class="steps">
-      <div class="step">
-        <div class="step-num sn-1">1</div>
-        <div class="step-label">指示を出す</div>
-        <div class="step-desc">Claude Code に<br>日本語で依頼</div>
-        <span class="step-arrow">▸</span>
-      </div>
-      <div class="step">
-        <div class="step-num sn-2">2</div>
-        <div class="step-label">AI が実装</div>
-        <div class="step-desc">コード作成<br>自動で完了</div>
-        <span class="step-arrow">▸</span>
-      </div>
-      <div class="step">
-        <div class="step-num sn-3">3</div>
-        <div class="step-label">ビルド</div>
-        <div class="step-desc">QuickBuild.ps1<br>を実行</div>
-        <span class="step-arrow">▸</span>
-      </div>
-      <div class="step">
-        <div class="step-num sn-4">4</div>
-        <div class="step-label">動作確認</div>
-        <div class="step-desc">Revit で<br>テスト</div>
-        <span class="step-arrow">▸</span>
-      </div>
-      <div class="step">
-        <div class="step-num sn-5">5</div>
-        <div class="step-label">完了!</div>
-        <div class="step-desc">OK なら<br>コミット</div>
-      </div>
     </div>
   </div>
 
-  <!-- ===== Release Flow ===== -->
-  <div class="workflow-section" style="margin-top:8px">
-    <div class="workflow-title"><span>🚀 リリースの流れ</span></div>
-    <div class="release-row">
-      <div class="step-wide" style="border-color:#475569">
-        <div class="step-num" style="background:#475569">1</div>
-        <div class="step-label">git tag & push</div>
-        <div class="step-desc">バージョンタグを付けてプッシュ</div>
-        <span class="step-arrow">▸</span>
+  <!-- ============================== -->
+  <!-- Phase 2: ビルド＆テスト         -->
+  <!-- ============================== -->
+  <div class="phase">
+    <div class="phase-header">ビルド＆テストフェーズ</div>
+    <div class="flow">
+
+      <!-- PowerShell 実行 -->
+      <div class="node node-you wide">
+        <div class="node-role">🙂 あなたが実行</div>
+        <div class="node-name">QuickBuild.ps1 を起動</div>
       </div>
-      <div class="step-wide" style="border-color:#64748b">
-        <div class="step-num" style="background:#64748b">2</div>
-        <div class="step-label">GitHub Actions</div>
-        <div class="step-desc">全版ビルド → ZIP自動生成</div>
-        <span class="step-arrow">▸</span>
+
+      <div class="arrow">
+        <div class="arrow-line"></div>
+        <div class="arrow-head">▼</div>
       </div>
-      <div class="step-wide" style="border-color:#ec4899">
-        <div class="step-num" style="background:#ec4899">3</div>
-        <div class="step-label">ユーザーに届く</div>
-        <div class="step-desc">Releases ページで公開・DL</div>
+
+      <!-- Branch: Build + Deploy -->
+      <div class="branch">
+        <div class="branch-col">
+          <div class="node node-auto">
+            <div class="node-role">⚙ 自動</div>
+            <div class="node-name">ビルド（変換）</div>
+          </div>
+          <div style="font-size:6pt;color:#a09888;margin-top:1mm;text-align:center;font-weight:700">
+            ← NuGet が部品を自動調達
+          </div>
+        </div>
+
+        <div class="branch-col" style="justify-content:center;padding-top:2mm">
+          <div class="harrow">
+            <div class="harrow-line"></div>
+            <div class="harrow-head">▸</div>
+          </div>
+        </div>
+
+        <div class="branch-col">
+          <div class="node node-auto">
+            <div class="node-role">⚙ 自動</div>
+            <div class="node-name">デプロイ（配置）</div>
+          </div>
+        </div>
       </div>
+
+      <div class="arrow">
+        <div class="arrow-line"></div>
+        <div class="arrow-head">▼</div>
+      </div>
+
+      <!-- Revit 動作確認 -->
+      <div class="node node-you wide">
+        <div class="node-role">🙂 あなたが操作</div>
+        <div class="node-name">Revit を起動して動作確認</div>
+        <div class="node-desc">「28 Tools」タブで新機能をテスト</div>
+      </div>
+
+      <!-- OK / NG -->
+      <div style="display:flex;gap:5mm;margin-top:2.5mm;align-items:center;justify-content:center">
+        <div>
+          <span class="badge badge-ok">✓ OK</span>
+          <span style="font-size:6.5pt;font-weight:700;color:#8a8078;margin-left:2px">→ 次のフェーズへ</span>
+        </div>
+        <div>
+          <span class="badge badge-ng">✗ NG</span>
+          <span style="font-size:6.5pt;font-weight:700;color:#8a8078;margin-left:2px">→ Claude Code に修正を指示 → 最初に戻る</span>
+        </div>
+      </div>
+
     </div>
   </div>
 
-  <!-- ===== Callout ===== -->
+  <!-- ============================== -->
+  <!-- Phase 3: リリースフェーズ       -->
+  <!-- ============================== -->
+  <div class="phase">
+    <div class="phase-header">リリースフェーズ</div>
+    <div class="flow">
+
+      <!-- Tag push -->
+      <div class="node node-you">
+        <div class="node-role">🙂 あなた</div>
+        <div class="node-name">タグを付けて送る</div>
+        <div class="node-desc">git tag vX.X → git push --tags</div>
+      </div>
+
+      <div class="arrow">
+        <div class="arrow-line"></div>
+        <div class="arrow-head">▼</div>
+      </div>
+
+      <!-- Horizontal: GitHub → Actions → Releases → Users -->
+      <div class="hrow">
+
+        <div class="node node-auto" style="width:auto;padding:2mm 3.5mm">
+          <div class="node-name" style="font-size:8pt">GitHub</div>
+          <div class="node-desc">台本倉庫</div>
+        </div>
+
+        <div class="harrow-up">
+          <div class="harrow-label">自動トリガー</div>
+          <div class="harrow">
+            <div class="harrow-line"></div>
+            <div class="harrow-head">▸</div>
+          </div>
+        </div>
+
+        <div class="node node-auto" style="width:auto;padding:2mm 3.5mm">
+          <div class="node-name" style="font-size:8pt">GitHub Actions</div>
+          <div class="node-desc">全版ビルド+ZIP</div>
+        </div>
+
+        <div class="harrow-up">
+          <div class="harrow-label">自動公開</div>
+          <div class="harrow">
+            <div class="harrow-line"></div>
+            <div class="harrow-head">▸</div>
+          </div>
+        </div>
+
+        <div class="node node-auto" style="width:auto;padding:2mm 3.5mm">
+          <div class="node-name" style="font-size:8pt">Releases</div>
+          <div class="node-desc">受け渡し窓口</div>
+        </div>
+
+        <div class="harrow-up">
+          <div class="harrow-label">ダウンロード</div>
+          <div class="harrow">
+            <div class="harrow-line"></div>
+            <div class="harrow-head">▸</div>
+          </div>
+        </div>
+
+        <div class="node" style="width:auto;padding:2mm 3.5mm;background:#fff">
+          <div class="node-name" style="font-size:8pt">ユーザー</div>
+          <div class="node-desc">install.bat 実行</div>
+        </div>
+
+      </div>
+
+    </div>
+  </div>
+
+  <!-- Callout -->
   <div class="callout">
-    <span class="callout-icon">💡</span>
-    <div class="callout-text">
-      <strong>ポイント：</strong>あなたはコードを一行も書く必要はありません。
-      Claude Code に「こういう機能がほしい」と伝えるだけで、実装からテスト準備まで AI が担当します。
-      あなたの役割は<strong>「指示」と「確認」</strong>の2つだけ!
-    </div>
+    <strong>💡 ポイント：</strong>あなたはコードを一行も書く必要はありません。
+    Claude Code に「こういう機能がほしい」と伝えるだけで、実装からテスト準備まで AI が担当します。
+    あなたの役割は<strong>「指示」と「確認」</strong>の2つだけ！
   </div>
 
-  <!-- ===== Footer ===== -->
+  <!-- Footer -->
   <div class="footer">
     Tools28 — Revit Add-in 開発プロジェクト ｜ <a href="https://github.com/28yu/Revit-Add-ins" target="_blank">GitHub</a>
   </div>
 
-</div><!-- /container -->
+</div><!-- /page -->
 
 </body>
 </html>


### PR DESCRIPTION
- Follow the 3-phase flow from development-workflow-summary.md: 開発フェーズ → ビルド＆テストフェーズ → リリースフェーズ
- A4 single-page layout (210mm × 297mm) with print support
- Reduced color palette to 2 tones: pale blue + warm beige/cream
- Vertical flowchart with connecting arrows matching the markdown correlation diagram structure
- Phase containers with clear headers and flow nodes
- OK/NG branching and NuGet side-feed shown inline
- Responsive fallback for mobile screens

https://claude.ai/code/session_013qcydagamBwD6erm85EVJ8