### PR TITLE
Add left-side icons to nodes, apply #93C572/#FFFDD0 color scheme

### DIFF
--- a/Docs/workflow-diagram.html
+++ b/Docs/workflow-diagram.html
@@ -11,7 +11,7 @@
 *{margin:0;padding:0;box-sizing:border-box}
 body{
   font-family:'Zen Maru Gothic','Hiragino Sans','Meiryo',sans-serif;
-  background:#f7f5f0;
+  background:#f5f3ee;
   color:#3a3632;
   line-height:1.45;
 }
@@ -23,21 +23,21 @@ body{
   max-width:100vw;
   margin:0 auto;
   background:#fff;
-  padding:18mm 14mm 12mm;
+  padding:16mm 14mm 10mm;
   box-shadow:0 1px 12px rgba(0,0,0,0.06);
 }
 
 /* ===== Title ===== */
 .title{
   text-align:center;
-  margin-bottom:5mm;
+  margin-bottom:4mm;
 }
 .title h1{
   font-size:15pt;
   font-weight:900;
   color:#3a3632;
   display:inline;
-  background:linear-gradient(transparent 55%,#d6e6f2 55%);
+  background:linear-gradient(transparent 55%,rgba(147,197,114,0.35) 55%);
   padding:0 4px;
 }
 .title-sub{
@@ -53,7 +53,7 @@ body{
   display:flex;
   justify-content:center;
   gap:14px;
-  margin-bottom:5mm;
+  margin-bottom:4mm;
 }
 .legend-item{
   display:flex;align-items:center;gap:4px;
@@ -63,91 +63,136 @@ body{
   width:8px;height:8px;border-radius:50%;
   border:1.5px solid;
 }
-.ld-you{background:#e8f0f6;border-color:#7baac8}
-.ld-ai{background:#e8f0f6;border-color:#7baac8}
+.ld-you{background:#FFFDD0;border-color:#c8bf8a}
+.ld-ai{background:#d8eacc;border-color:#93C572}
 .ld-auto{background:#f0ece5;border-color:#c4baa8}
 
 /* ===== Phase Container ===== */
 .phase{
-  border:1.5px solid #d8d2c8;
+  border:1.5px solid #c6d9b8;
   border-radius:8px;
-  margin-bottom:4mm;
+  margin-bottom:3.5mm;
   overflow:hidden;
 }
 .phase-header{
-  background:#f0ece5;
-  padding:2.5mm 4mm;
+  background:#93C572;
+  padding:2mm 4mm;
   font-size:9pt;
   font-weight:900;
-  color:#5a5347;
-  border-bottom:1.5px solid #d8d2c8;
+  color:#fff;
+  border-bottom:1.5px solid #7fb562;
 }
 
 /* ===== Vertical Flow ===== */
 .flow{
-  padding:4mm 4mm;
+  padding:3.5mm 4mm;
   display:flex;
   flex-direction:column;
   align-items:center;
   gap:0;
 }
 
-/* Node */
+/* ===== Node with left icon ===== */
 .node{
   background:#fff;
-  border:1.5px solid #c8d8e4;
+  border:1.5px solid #c6d9b8;
   border-radius:7px;
-  padding:2.5mm 5mm;
-  text-align:center;
-  width:58mm;
+  padding:2mm 4mm;
+  width:72mm;
   position:relative;
+  display:flex;
+  align-items:center;
+  gap:3mm;
 }
-.node.wide{width:72mm}
+.node-icon{
+  width:9mm;
+  height:9mm;
+  border-radius:50%;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  font-size:12pt;
+  flex-shrink:0;
+  background:#FFFDD0;
+  border:1.5px solid #ddd8b0;
+}
+.node-text{
+  flex:1;
+  min-width:0;
+}
 .node-role{
-  font-size:7pt;
+  font-size:6.5pt;
   font-weight:700;
   color:#8a8078;
-  margin-bottom:0.5mm;
+  margin-bottom:0.3mm;
 }
 .node-name{
-  font-size:9.5pt;
+  font-size:9pt;
   font-weight:900;
   color:#3a3632;
+  line-height:1.35;
 }
 .node-desc{
-  font-size:7pt;
+  font-size:6.5pt;
   font-weight:500;
-  color:#7a7268;
-  margin-top:0.5mm;
-  line-height:1.4;
-}
-.node-you{
-  background:#e8f0f6;
-  border-color:#a8c8dc;
-}
-.node-auto{
-  background:#f5f2ec;
-  border-color:#d0c8b8;
+  color:#8a8078;
+  margin-top:0.3mm;
+  line-height:1.35;
 }
 
-/* Arrow (vertical connector) */
+/* Node variations */
+.node-you{
+  background:#FFFDD0;
+  border-color:#ddd8b0;
+}
+.node-you .node-icon{
+  background:#fff;
+  border-color:#ddd8b0;
+}
+.node-auto{
+  background:#f4f8f0;
+  border-color:#c6d9b8;
+}
+.node-auto .node-icon{
+  background:#d8eacc;
+  border-color:#b0d49a;
+}
+.node-ai .node-icon{
+  background:#d8eacc;
+  border-color:#b0d49a;
+}
+
+/* Small node (for horizontal row) */
+.node-sm{
+  width:auto;
+  padding:1.5mm 3mm;
+}
+.node-sm .node-icon{
+  width:7mm;height:7mm;
+  font-size:9pt;
+}
+.node-sm .node-name{font-size:7.5pt}
+.node-sm .node-desc{font-size:6pt}
+
+/* ===== Arrow (vertical connector) ===== */
 .arrow{
   display:flex;
   flex-direction:column;
   align-items:center;
-  padding:1mm 0;
-  color:#b0a898;
+  padding:0.8mm 0;
+  color:#93C572;
   position:relative;
 }
 .arrow-line{
   width:1.5px;
-  height:4mm;
-  background:#c4baa8;
+  height:3.5mm;
+  background:#b0d49a;
 }
 .arrow-head{
   font-size:7pt;
   line-height:1;
   margin-top:-1px;
+  color:#93C572;
 }
 .arrow-label{
   font-size:6.5pt;
@@ -159,16 +204,12 @@ body{
   transform:translateY(-50%);
   white-space:nowrap;
 }
-.arrow-label-left{
-  left:auto;
-  right:calc(50% + 6mm);
-}
 
-/* Horizontal row */
+/* ===== Horizontal row ===== */
 .hrow{
   display:flex;
   align-items:center;
-  gap:3mm;
+  gap:2mm;
   width:100%;
   justify-content:center;
 }
@@ -176,12 +217,12 @@ body{
   display:flex;
   align-items:center;
   gap:0;
-  color:#b0a898;
+  color:#93C572;
 }
 .harrow-line{
-  width:5mm;
+  width:4mm;
   height:1.5px;
-  background:#c4baa8;
+  background:#b0d49a;
 }
 .harrow-head{
   font-size:7pt;
@@ -189,7 +230,7 @@ body{
   margin-left:-1px;
 }
 .harrow-label{
-  font-size:6.5pt;
+  font-size:6pt;
   font-weight:700;
   color:#8a8078;
   white-space:nowrap;
@@ -200,11 +241,11 @@ body{
   align-items:center;
 }
 
-/* Branch split */
+/* ===== Branch split ===== */
 .branch{
   display:flex;
   align-items:flex-start;
-  gap:4mm;
+  gap:3mm;
   width:100%;
   justify-content:center;
 }
@@ -215,43 +256,29 @@ body{
   gap:0;
 }
 
-/* Feedback loop */
-.feedback{
-  display:flex;
-  align-items:center;
-  gap:2mm;
-  margin-top:2mm;
-  padding:1.5mm 4mm;
-  background:#faf7f2;
-  border:1px dashed #d0c8b8;
-  border-radius:5px;
-  font-size:6.5pt;
-  font-weight:700;
-  color:#8a8078;
-}
-
-/* Side annotation */
-.side-note{
-  position:absolute;
-  font-size:6pt;
-  font-weight:700;
-  color:#a09888;
-  white-space:nowrap;
-}
-
-/* Result node (code) */
+/* ===== Result node ===== */
 .node-result{
-  background:#f5f2ec;
-  border:1.5px dashed #c4baa8;
+  background:#f4f8f0;
+  border:1.5px dashed #b0d49a;
   border-radius:7px;
-  padding:2mm 5mm;
+  padding:1.5mm 5mm;
   text-align:center;
   font-size:8pt;
   font-weight:700;
-  color:#6a6258;
+  color:#5a6e4a;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  gap:2mm;
+}
+.node-result .node-icon{
+  width:7mm;height:7mm;
+  font-size:9pt;
+  background:#d8eacc;
+  border-color:#b0d49a;
 }
 
-/* OK/NG badges */
+/* ===== OK/NG badges ===== */
 .badge{
   display:inline-block;
   padding:0.5mm 2.5mm;
@@ -259,14 +286,23 @@ body{
   font-size:6.5pt;
   font-weight:900;
 }
-.badge-ok{background:#e8f0f6;color:#5a8aa8}
-.badge-ng{background:#f0ece5;color:#8a7a68}
+.badge-ok{background:#d8eacc;color:#4a7a38}
+.badge-ng{background:#FFFDD0;color:#8a7a50}
+
+/* ===== NuGet note ===== */
+.nuget-note{
+  font-size:6pt;
+  color:#8a8078;
+  margin-top:0.8mm;
+  text-align:center;
+  font-weight:700;
+}
 
 /* ===== Callout ===== */
 .callout{
-  margin-top:4mm;
-  background:#f0ece5;
-  border:1.5px solid #d8d2c8;
+  margin-top:3.5mm;
+  background:#FFFDD0;
+  border:1.5px solid #ddd8b0;
   border-radius:7px;
   padding:2.5mm 4mm;
   font-size:7pt;
@@ -279,35 +315,26 @@ body{
 /* ===== Footer ===== */
 .footer{
   text-align:center;
-  margin-top:3mm;
+  margin-top:2.5mm;
   font-size:6.5pt;
   color:#a09888;
   font-weight:700;
 }
-.footer a{color:#7baac8;text-decoration:none}
+.footer a{color:#6a9e52;text-decoration:none}
 
 /* ===== Print ===== */
 @media print{
   body{background:#fff}
-  .page{
-    box-shadow:none;
-    padding:10mm 12mm 8mm;
-    min-height:auto;
-  }
+  .page{box-shadow:none;padding:10mm 12mm 8mm;min-height:auto}
 }
 
 /* ===== Responsive ===== */
 @media(max-width:600px){
-  .page{
-    width:100%;
-    padding:5mm 4mm;
-    min-height:auto;
-  }
+  .page{width:100%;padding:5mm 4mm;min-height:auto}
   .hrow{flex-direction:column;gap:0}
   .harrow{transform:rotate(90deg)}
   .branch{flex-direction:column;align-items:center}
-  .node{width:auto;max-width:90%}
-  .node.wide{width:auto;max-width:90%}
+  .node{width:auto;max-width:95%}
 }
 </style>
 </head>
@@ -336,9 +363,12 @@ body{
     <div class="flow">
 
       <!-- あなた -->
-      <div class="node node-you wide">
-        <div class="node-role">🙂 あなた ─ 監督・プロデューサー</div>
-        <div class="node-name">作りたい機能を考える・仕様をまとめる</div>
+      <div class="node node-you">
+        <div class="node-icon">🙂</div>
+        <div class="node-text">
+          <div class="node-role">あなた ─ 監督・プロデューサー</div>
+          <div class="node-name">作りたい機能を考える・仕様をまとめる</div>
+        </div>
       </div>
 
       <div class="arrow">
@@ -348,10 +378,13 @@ body{
       </div>
 
       <!-- Claude Code -->
-      <div class="node wide">
-        <div class="node-role">🤖 Claude Code ─ AI 脚本家</div>
-        <div class="node-name">コードを全て書く</div>
-        <div class="node-desc">コマンドクラス (.cs) / WPF (XAML) / Application.cs / csproj</div>
+      <div class="node node-ai">
+        <div class="node-icon">🤖</div>
+        <div class="node-text">
+          <div class="node-role">Claude Code ─ AI 脚本家</div>
+          <div class="node-name">コードを全て書く</div>
+          <div class="node-desc">コマンドクラス (.cs) / WPF (XAML) / Application.cs / csproj</div>
+        </div>
       </div>
 
       <div class="arrow">
@@ -360,7 +393,10 @@ body{
       </div>
 
       <!-- Code -->
-      <div class="node-result" style="width:48mm">コード（設計図）が完成</div>
+      <div class="node-result">
+        <div class="node-icon">📄</div>
+        コード（設計図）が完成
+      </div>
 
       <div class="arrow">
         <div class="arrow-line"></div>
@@ -379,9 +415,12 @@ body{
     <div class="flow">
 
       <!-- PowerShell 実行 -->
-      <div class="node node-you wide">
-        <div class="node-role">🙂 あなたが実行</div>
-        <div class="node-name">QuickBuild.ps1 を起動</div>
+      <div class="node node-you">
+        <div class="node-icon">🙂</div>
+        <div class="node-text">
+          <div class="node-role">あなたが実行</div>
+          <div class="node-name">QuickBuild.ps1 を起動</div>
+        </div>
       </div>
 
       <div class="arrow">
@@ -392,16 +431,16 @@ body{
       <!-- Branch: Build + Deploy -->
       <div class="branch">
         <div class="branch-col">
-          <div class="node node-auto">
-            <div class="node-role">⚙ 自動</div>
-            <div class="node-name">ビルド（変換）</div>
+          <div class="node node-auto node-sm">
+            <div class="node-icon">⚙️</div>
+            <div class="node-text">
+              <div class="node-name">ビルド（変換）</div>
+            </div>
           </div>
-          <div style="font-size:6pt;color:#a09888;margin-top:1mm;text-align:center;font-weight:700">
-            ← NuGet が部品を自動調達
-          </div>
+          <div class="nuget-note">← NuGet が部品を自動調達</div>
         </div>
 
-        <div class="branch-col" style="justify-content:center;padding-top:2mm">
+        <div class="branch-col" style="justify-content:center;padding-top:1.5mm">
           <div class="harrow">
             <div class="harrow-line"></div>
             <div class="harrow-head">▸</div>
@@ -409,9 +448,11 @@ body{
         </div>
 
         <div class="branch-col">
-          <div class="node node-auto">
-            <div class="node-role">⚙ 自動</div>
-            <div class="node-name">デプロイ（配置）</div>
+          <div class="node node-auto node-sm">
+            <div class="node-icon">⚙️</div>
+            <div class="node-text">
+              <div class="node-name">デプロイ（配置）</div>
+            </div>
           </div>
         </div>
       </div>
@@ -422,21 +463,24 @@ body{
       </div>
 
       <!-- Revit 動作確認 -->
-      <div class="node node-you wide">
-        <div class="node-role">🙂 あなたが操作</div>
-        <div class="node-name">Revit を起動して動作確認</div>
-        <div class="node-desc">「28 Tools」タブで新機能をテスト</div>
+      <div class="node node-you">
+        <div class="node-icon">🔍</div>
+        <div class="node-text">
+          <div class="node-role">あなたが操作</div>
+          <div class="node-name">Revit を起動して動作確認</div>
+          <div class="node-desc">「28 Tools」タブで新機能をテスト</div>
+        </div>
       </div>
 
       <!-- OK / NG -->
-      <div style="display:flex;gap:5mm;margin-top:2.5mm;align-items:center;justify-content:center">
+      <div style="display:flex;gap:5mm;margin-top:2mm;align-items:center;justify-content:center">
         <div>
           <span class="badge badge-ok">✓ OK</span>
-          <span style="font-size:6.5pt;font-weight:700;color:#8a8078;margin-left:2px">→ 次のフェーズへ</span>
+          <span style="font-size:6.5pt;font-weight:700;color:#8a8078;margin-left:1px">→ 次のフェーズへ</span>
         </div>
         <div>
           <span class="badge badge-ng">✗ NG</span>
-          <span style="font-size:6.5pt;font-weight:700;color:#8a8078;margin-left:2px">→ Claude Code に修正を指示 → 最初に戻る</span>
+          <span style="font-size:6.5pt;font-weight:700;color:#8a8078;margin-left:1px">→ Claude Code に修正指示 → 最初に戻る</span>
         </div>
       </div>
 
@@ -451,10 +495,13 @@ body{
     <div class="flow">
 
       <!-- Tag push -->
-      <div class="node node-you">
-        <div class="node-role">🙂 あなた</div>
-        <div class="node-name">タグを付けて送る</div>
-        <div class="node-desc">git tag vX.X → git push --tags</div>
+      <div class="node node-you" style="width:62mm">
+        <div class="node-icon">🏷️</div>
+        <div class="node-text">
+          <div class="node-role">あなた</div>
+          <div class="node-name">タグを付けて送る</div>
+          <div class="node-desc">git tag vX.X → git push --tags</div>
+        </div>
       </div>
 
       <div class="arrow">
@@ -465,9 +512,12 @@ body{
       <!-- Horizontal: GitHub → Actions → Releases → Users -->
       <div class="hrow">
 
-        <div class="node node-auto" style="width:auto;padding:2mm 3.5mm">
-          <div class="node-name" style="font-size:8pt">GitHub</div>
-          <div class="node-desc">台本倉庫</div>
+        <div class="node node-auto node-sm">
+          <div class="node-icon">🐙</div>
+          <div class="node-text">
+            <div class="node-name">GitHub</div>
+            <div class="node-desc">台本倉庫</div>
+          </div>
         </div>
 
         <div class="harrow-up">
@@ -478,9 +528,12 @@ body{
           </div>
         </div>
 
-        <div class="node node-auto" style="width:auto;padding:2mm 3.5mm">
-          <div class="node-name" style="font-size:8pt">GitHub Actions</div>
-          <div class="node-desc">全版ビルド+ZIP</div>
+        <div class="node node-auto node-sm">
+          <div class="node-icon">⚡</div>
+          <div class="node-text">
+            <div class="node-name">Actions</div>
+            <div class="node-desc">全版ビルド+ZIP</div>
+          </div>
         </div>
 
         <div class="harrow-up">
@@ -491,9 +544,12 @@ body{
           </div>
         </div>
 
-        <div class="node node-auto" style="width:auto;padding:2mm 3.5mm">
-          <div class="node-name" style="font-size:8pt">Releases</div>
-          <div class="node-desc">受け渡し窓口</div>
+        <div class="node node-auto node-sm">
+          <div class="node-icon">📦</div>
+          <div class="node-text">
+            <div class="node-name">Releases</div>
+            <div class="node-desc">受け渡し窓口</div>
+          </div>
         </div>
 
         <div class="harrow-up">
@@ -504,9 +560,12 @@ body{
           </div>
         </div>
 
-        <div class="node" style="width:auto;padding:2mm 3.5mm;background:#fff">
-          <div class="node-name" style="font-size:8pt">ユーザー</div>
-          <div class="node-desc">install.bat 実行</div>
+        <div class="node node-sm" style="background:#FFFDD0;border-color:#ddd8b0">
+          <div class="node-icon">👥</div>
+          <div class="node-text">
+            <div class="node-name">ユーザー</div>
+            <div class="node-desc">install.bat 実行</div>
+          </div>
         </div>
 
       </div>


### PR DESCRIPTION
- Restructure all nodes to display icon circle on the left side of the text content (flex row layout with node-icon + node-text)
- Replace entire color palette with two specified colors:
  - #93C572 (pistachio green): phase headers, borders, arrows, accents
  - #FFFDD0 (cream): user-action node backgrounds, callout, badges
- Icon circles with consistent sizing (9mm main, 7mm small nodes)
- All nodes including result node, branch nodes, and release row nodes now have left-aligned icons

https://claude.ai/code/session_013qcydagamBwD6erm85EVJ8