### PR TITLE
Fix icon sizing: use object-fit contain with padding for full visibility

### DIFF
--- a/Docs/workflow-diagram.html
+++ b/Docs/workflow-diagram.html
@@ -118,9 +118,9 @@ body{
   overflow:hidden;
 }
 .node-icon img{
-  width:100%;
-  height:100%;
-  object-fit:cover;
+  width:80%;
+  height:80%;
+  object-fit:contain;
   display:block;
 }
 .node-text{


### PR DESCRIPTION
Change node-icon img from cover (100%) to contain (80%) so line-art icons like you.png and user.png fit fully inside the circle without being cropped.

https://claude.ai/code/session_013qcydagamBwD6erm85EVJ8